### PR TITLE
Do nothing when noninteractive is non-nil

### DIFF
--- a/evil-terminal-cursor-changer.el
+++ b/evil-terminal-cursor-changer.el
@@ -259,7 +259,7 @@ echo -n $TERM_PROFILE"))
 
 (defun etcc--evil-set-cursor (&rest _)
   "Set cursor color type."
-  (unless (display-graphic-p)
+  (unless (or (display-graphic-p) noninteractive)
     (if (symbolp cursor-type)
         (etcc--apply-to-terminal (etcc--make-cursor-shape-seq cursor-type))
       (if (listp cursor-type)


### PR DESCRIPTION
Ran into some issues w/ cursor changing in noninteractive (batch) mode. This should be innocuous as there's no reason to change cursor in noninteractive mode afaik.