### PR TITLE
Add customizable terminal type override

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ plus(https://github.com/saitoha/mouseterm-plus/releases) to use
 evil-terminal-cursor-changer. That makes to support VT's DECSCUSR
 sequence.
 
+If your terminal is not correctly detected, but you know that the escape
+sequences used for one of the supported terminals will work, you can override
+the terminal detection by setting `etcc-term-type-override`, which is available
+to set interactively in the `customize` facility (run `M-x customize-group RET
+evil-terminal-cursor-changer RET`).
+
 ## Change Log
 
 This program is free software; you can redistribute it and/or

--- a/evil-terminal-cursor-changer.el
+++ b/evil-terminal-cursor-changer.el
@@ -102,29 +102,48 @@
   :type 'boolean
   :group 'evil-terminal-cursor-changer)
 
+(defcustom etcc-term-type-override nil
+  "The type of terminal sequence to send.
+
+Set this if your terminal is not correctly detected."
+  :type `(choice (const :tag "(Autodetect)" ,nil)
+                 (const :tag "Dumb" dumb)
+                 (const :tag "Xterm" xterm)
+                 (const :tag "iTerm" iterm)
+                 (const :tag "Gnome Terminal" gnome)
+                 (const :tag "Konsole" konsole)
+                 (const :tag "Apple Terminal" apple))
+  :group 'evil-terminal-cursor-changer)
+
 (defun etcc--in-dumb? ()
   "Running in dumb."
-  (string= (getenv "TERM") "dumb"))
+  (or (eq etcc-term-type-override 'dumb)
+      (string= (getenv "TERM") "dumb")))
 
 (defun etcc--in-iterm? ()
   "Running in iTerm."
-  (string= (getenv "TERM_PROGRAM") "iTerm.app"))
+  (or (eq etcc-term-type-override 'iterm)
+      (string= (getenv "TERM_PROGRAM") "iTerm.app")))
 
 (defun etcc--in-xterm? ()
   "Runing in xterm."
-  (getenv "XTERM_VERSION"))
+  (or (eq etcc-term-type-override 'xterm)
+      (getenv "XTERM_VERSION")))
 
 (defun etcc--in-gnome-terminal? ()
   "Running in gnome-terminal."
-  (string= (getenv "COLORTERM") "gnome-terminal"))
+  (or (eq etcc-term-type-override 'gnome)
+      (string= (getenv "COLORTERM") "gnome-terminal")))
 
 (defun etcc--in-konsole? ()
   "Running in konsole."
-  (getenv "KONSOLE_PROFILE_NAME"))
+  (or (eq etcc-term-type-override 'konsole)
+      (getenv "KONSOLE_PROFILE_NAME")))
 
 (defun etcc--in-apple-terminal? ()
-  "Running in Apple Terminal"
-  (string= (getenv "TERM_PROGRAM") "Apple_Terminal"))
+  "Running in Apple Terminal."
+  (or (eq etcc-term-type-override 'apple)
+      (string= (getenv "TERM_PROGRAM") "Apple_Terminal")))
 
 (defun etcc--in-tmux? ()
   "Running in tmux."


### PR DESCRIPTION
This patch adds a user-selectable terminal type override, which resolves #24.

I added some explanatory text to README as well.