### PR TITLE
enable lexical binding

### DIFF
--- a/evil-terminal-cursor-changer.el
+++ b/evil-terminal-cursor-changer.el
@@ -1,4 +1,4 @@
-;;; evil-terminal-cursor-changer.el --- Change cursor shape and color by evil state in terminal  -*- coding: utf-8; -*-
+;;; evil-terminal-cursor-changer.el --- Change cursor shape and color by evil state in terminal  -*- lexical-binding: t; coding: utf-8; -*-
 ;;
 ;; Filename: evil-terminal-cursor-changer.el
 ;; Description: Change cursor shape and color by evil state in terminal.


### PR DESCRIPTION
Hi. I have inspected your codebase and found no code which presents a problem with enabling `lexical-binding`. One day Emacs will enable lexical binding by default so it's better merge this earlier to reduce the risk of a mass config breakage event. 