### PR TITLE
Add Kitty Terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If want change cursor shape type, add below line. This is evil's setting.
          (setq evil-emacs-state-cursor  'hbar) ; _
 
 Now, works in XTerm, Gnome Terminal(Gnome Desktop), iTerm(Mac OS
-X), Konsole(KDE Desktop), dumb(etc. mintty), Apple
+X), Konsole(KDE Desktop), dumb(etc. mintty), Kitty, Apple
 Terminal.app(restrictive supporting). If using Apple Terminal.app,
 must install SIMBL(http://www.culater.net/software/SIMBL/SIMBL.php)
 and MouseTerm

--- a/evil-terminal-cursor-changer.el
+++ b/evil-terminal-cursor-changer.el
@@ -111,7 +111,8 @@ Set this if your terminal is not correctly detected."
                  (const :tag "iTerm" iterm)
                  (const :tag "Gnome Terminal" gnome)
                  (const :tag "Konsole" konsole)
-                 (const :tag "Apple Terminal" apple))
+                 (const :tag "Apple Terminal" apple)
+		 (const :tag "Kitty" kitty))
   :group 'evil-terminal-cursor-changer)
 
 (defun etcc--in-dumb? ()
@@ -143,6 +144,11 @@ Set this if your terminal is not correctly detected."
   "Running in Apple Terminal."
   (or (eq etcc-term-type-override 'apple)
       (string= (getenv "TERM_PROGRAM") "Apple_Terminal")))
+
+(defun etcc--in-kitty? ()
+  "Running in Kitty."
+  (or (eq etcc-term-type-override 'kitty)
+      (getenv "KITTY_PID")))
 
 (defun etcc--get-current-gnome-profile-name ()
   "Return Current profile name of Gnome Terminal."
@@ -220,7 +226,8 @@ echo -n $TERM_PROFILE"))
   "Make escape sequence for cursor shape."
   (cond ((or (etcc--in-xterm?)
              (etcc--in-apple-terminal?)
-             (etcc--in-iterm?))
+             (etcc--in-iterm?)
+	     (etcc--in-kitty?))
          (etcc--make-xterm-cursor-shape-seq shape))
         ((etcc--in-konsole?)
          (etcc--make-konsole-cursor-shape-seq shape))


### PR DESCRIPTION
Kitty is a GPU based terminal emulator which use the same mechanism as xterm to change curosor shape.

For example:

  printf '\e[1 q' # box blink
  printf '\e[2 q' # box blink
  printf '\e[3 q' # hbar blink
  printf '\e[4 q' # hbar
  printf '\e[5 q' # bar blink
  printf '\e[6 q' # bar

We can also use (getenv "KITTY_PID") to check if current emacs is launched from kitty or not.

Fixed #30 